### PR TITLE
Don't use undefined value in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.build.Builder) void {
     const mode = b.standardOptimizeOption(.{});
     b.prominent_compile_errors = true;
 
-    const op = b.option([]const u8, "algorithm", "choice algoritm to build.") orelse undefined;
+    const op = b.option([]const u8, "algorithm", "choice algoritm to build.") orelse return;
 
     // Sort algorithms
     if (std.mem.eql(u8, op, "sort/quicksort"))


### PR DESCRIPTION
Using `undefined` here can trigger UB - instead `return` early.