### PR TITLE
Web Examples and Summary Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,6 @@
  * [Code of Conduct](CODE_OF_CONDUCT.md)
  
 
-### TODO
-
-- **Data Structures**
-- **Graph**
-- **Math**
-- **Sort**
-- **Search**
-- **Dynamic Programming**
-- **Concurrency & Parallelism**
-
 ### How to build
 
 **Require:**

--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,6 @@ const std = @import("std");
 pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
     const mode = b.standardOptimizeOption(.{});
-    b.prominent_compile_errors = true;
 
     const op = b.option([]const u8, "algorithm", "choice algoritm to build.") orelse return;
 
@@ -50,14 +49,15 @@ pub fn build(b: *std.build.Builder) void {
         build_algorithm(b, mode, target, "factorial.zig", "math");
 
     // Concurrent
-
     if (std.mem.eql(u8, op, "threads/threadpool"))
         build_algorithm(b, mode, target, "ThreadPool.zig", "concurrency/threads");
+
+    // Web
+    if (std.mem.eql(u8, op, "web/tls1_3"))
+        build_algorithm(b, mode, target, "X25519+Kyber768Draft00.zig", "web/tls");
 }
 
 fn build_algorithm(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, name: []const u8, path: []const u8) void {
-    std.debug.print("Building {s}\n", .{name});
-
     const src = std.mem.concat(b.allocator, u8, &.{ path, "/", name }) catch @panic("concat error");
     const exe_tests = b.addTest(.{
         .name = name,

--- a/build.zig
+++ b/build.zig
@@ -53,6 +53,8 @@ pub fn build(b: *std.build.Builder) void {
         build_algorithm(b, mode, target, "ThreadPool.zig", "concurrency/threads");
 
     // Web
+    if (std.mem.eql(u8, op, "web/http"))
+        build_algorithm(b, mode, target, "client.zig", "web/http");
     if (std.mem.eql(u8, op, "web/tls1_3"))
         build_algorithm(b, mode, target, "X25519+Kyber768Draft00.zig", "web/tls");
 }

--- a/runall.sh
+++ b/runall.sh
@@ -38,6 +38,7 @@ $ZIG_TEST -Dalgorithm=search/rb $Args
 $ZIG_TEST -Dalgorithm=threads/threadpool $Args
 
 ## Web
+$ZIG_TEST -Dalgorithm=web/http $Args
 $ZIG_TEST -Dalgorithm=web/tls1_3 $Args
 
 ## Add more...

--- a/runall.sh
+++ b/runall.sh
@@ -2,40 +2,42 @@
 
 ZIG_TEST='zig build test'
 
-# reference trace should be shown per compile error
-StackTrace='-freference-trace'
+# -fsummary                    Print the build summary, even on success
+# -freference-trace            Reference trace should be shown per compile error
+Args='-fsummary -freference-trace'
 
 ## Test all algorithms
 
 # Math
-$ZIG_TEST -Dalgorithm=math/ceil $StackTrace
-$ZIG_TEST -Dalgorithm=math/crt $StackTrace
-$ZIG_TEST -Dalgorithm=math/primes $StackTrace
-$ZIG_TEST -Dalgorithm=math/fibonacci $StackTrace
-$ZIG_TEST -Dalgorithm=math/factorial $StackTrace
-$ZIG_TEST -Dalgorithm=math/euclidianGCDivisor $StackTrace
-$ZIG_TEST -Dalgorithm=math/gcd $StackTrace
+$ZIG_TEST -Dalgorithm=math/ceil $Args
+$ZIG_TEST -Dalgorithm=math/crt $Args
+$ZIG_TEST -Dalgorithm=math/primes $Args
+$ZIG_TEST -Dalgorithm=math/fibonacci $Args
+$ZIG_TEST -Dalgorithm=math/factorial $Args
+$ZIG_TEST -Dalgorithm=math/euclidianGCDivisor $Args
+$ZIG_TEST -Dalgorithm=math/gcd $Args
 
 # Data Structures
-$ZIG_TEST -Dalgorithm=ds/linkedlist $StackTrace
-$ZIG_TEST -Dalgorithm=ds/lrucache $StackTrace
+$ZIG_TEST -Dalgorithm=ds/linkedlist $Args
+$ZIG_TEST -Dalgorithm=ds/lrucache $Args
 
 # Dynamic Programming
 
 ## Sort
-$ZIG_TEST -Dalgorithm=sort/quicksort $StackTrace
-$ZIG_TEST -Dalgorithm=sort/bubblesort $StackTrace
-$ZIG_TEST -Dalgorithm=sort/radixsort $StackTrace
-$ZIG_TEST -Dalgorithm=sort/mergesort $StackTrace
-$ZIG_TEST -Dalgorithm=sort/insertsort $StackTrace
+$ZIG_TEST -Dalgorithm=sort/quicksort $Args
+$ZIG_TEST -Dalgorithm=sort/bubblesort $Args
+$ZIG_TEST -Dalgorithm=sort/radixsort $Args
+$ZIG_TEST -Dalgorithm=sort/mergesort $Args
+$ZIG_TEST -Dalgorithm=sort/insertsort $Args
 
 ## Search
-$ZIG_TEST -Dalgorithm=search/bSearchTree $StackTrace
-$ZIG_TEST -Dalgorithm=search/rb $StackTrace
-
-# Concurrency && Parallelism
+$ZIG_TEST -Dalgorithm=search/bSearchTree $Args
+$ZIG_TEST -Dalgorithm=search/rb $Args
 
 ## Threads
-$ZIG_TEST -Dalgorithm="threads/threadpool" $StackTrace
+$ZIG_TEST -Dalgorithm=threads/threadpool $Args
+
+## Web
+$ZIG_TEST -Dalgorithm=web/tls1_3 $Args
 
 ## Add more...

--- a/web/http/client.zig
+++ b/web/http/client.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+
+test "Status == 200" {
+    const uri = std.Uri.parse("https://ziglang.org/") catch unreachable;
+    var client: std.http.Client = .{ .allocator = std.testing.allocator };
+    defer client.deinit();
+
+    var req = try client.request(uri, .{}, .{});
+    defer req.deinit();
+
+    try std.testing.expect(req.response.headers.status == .ok);
+}

--- a/web/tls/X25519+Kyber768Draft00.zig
+++ b/web/tls/X25519+Kyber768Draft00.zig
@@ -1,0 +1,39 @@
+//! Reference: https://github.com/ziglang/zig/pull/14920
+//! by: https://github.com/bwesterb
+
+test "HTTPS Client - X25519+Kyber768Draft00" {
+    const hdrs = std.http.Client.Request.Headers{};
+    const opts = std.http.Client.Request.Options{};
+    var buf: [1000]u8 = undefined;
+    const uri = try std.Uri.parse("https://cloudflare.com/cdn-cgi/trace");
+    var client = std.http.Client{
+        .allocator = testing.allocator,
+    };
+    defer client.deinit();
+
+    var req = try client.request(uri, hdrs, opts);
+    try req.finish();
+    defer req.deinit();
+    const read = try req.readAll(&buf);
+
+    var strings = std.mem.split(u8, buf[0..read], "\n");
+    var index = strings.index.?;
+
+    while (index < strings.rest().len) : (index += 1) {
+        const content = strings.next().?;
+        if (startW(u8, content, "h="))
+            try testing.expectEqualStrings("h=cloudflare.com", content);
+        if (startW(u8, content, "visit_scheme="))
+            try testing.expectEqualStrings("visit_scheme=https", content);
+        if (startW(u8, content, "http="))
+            try testing.expectEqualStrings("http=http/1.1", content);
+        if (startW(u8, content, "uag="))
+            try testing.expectEqualStrings("uag=zig (std.http)", content);
+        if (startW(u8, content, "tls="))
+            try testing.expectEqualStrings("tls=TLSv1.3", content);
+    }
+}
+
+const std = @import("std");
+const testing = std.testing;
+const startW = std.mem.startsWith;


### PR DESCRIPTION
* TLS v1.3 - Kyber768
* HTTP Client
* Summary Test

There have been some changes that have broken the old compatibility.
The `--prominent-compile-errors` does not work anymore until the present moment. (is_prominent default)
- https://github.com/ziglang/zig/pull/14647
- https://github.com/ziglang/zig/pull/14999