### PR TITLE
zig update - v0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ### How to build
 
 **Require:**
-- [Zig v0.14 or higher](https://ziglang.org/download), self-hosting (stage3) compiler.
+- [Zig v0.15.1 or higher](https://ziglang.org/download), self-hosting (stage3) compiler.
 
 ### Test all
 

--- a/build.zig
+++ b/build.zig
@@ -217,7 +217,7 @@ pub fn build(b: *std.Build) void {
             .category = "machine_learning",
         });
     // Numerical Methods
-    if (std.mem.eql(u8, op, "numerical_methods/newton_raphson_root"))
+    if (std.mem.eql(u8, op, "numerical_methods/newton_raphson"))
         buildAlgorithm(b, .{
             .optimize = optimize,
             .target = target,

--- a/build.zig
+++ b/build.zig
@@ -235,11 +235,15 @@ fn buildAlgorithm(b: *std.Build, info: BInfo) void {
 
     const runner = b.dependency("runner", .{}).path("test_runner.zig");
 
-    const exe_tests = b.addTest(.{
-        .name = info.name,
+    const mod = b.addModule(info.name, .{
+        .root_source_file = b.path(src),
         .target = info.target,
         .optimize = info.optimize,
-        .root_source_file = b.path(src),
+    });
+
+    const exe_tests = b.addTest(.{
+        .name = info.name,
+        .root_module = mod,
         .test_runner = .{ .path = runner, .mode = .simple },
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,7 +28,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -38,8 +38,8 @@
     .dependencies = .{
         // Custom test-runner: see tests output
         .runner = .{
-            .url = "git+https://gist.github.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b/#1f317ebc9cd09bc50fd5591d09c34255e15d1d85",
-            .hash = "N-V-__8AANwlAADW-4Yu_sYSZkL_6wcz13gOf9pkOLCjct-F",
+            .url = "git+https://gist.github.com/karlseguin/c6bea5b35e4e8d26af6f81c22cb5d76b#eb15512d6ae49663fa9df6c7a9725b20dab43edd",
+            .hash = "N-V-__8AAHMkAAC4CUVVTX0UMBJXtfOubskbF9EJ7X6qAGYR",
         },
     },
     .paths = .{

--- a/dynamicProgramming/longestIncreasingSubsequence.zig
+++ b/dynamicProgramming/longestIncreasingSubsequence.zig
@@ -30,15 +30,15 @@ pub fn lowerBound(arr: []const i32, key: i32) usize {
 //      arr: the passed array
 //      allocator: Any std.heap type allocator
 pub fn lis(arr: []const i32, allocator: anytype) usize {
-    var v = ArrayList(i32).init(allocator);
-    defer v.deinit();
+    var v: ArrayList(i32) = .empty;
+    defer v.deinit(allocator);
 
     const n = arr.len;
 
     for (0..n) |i| {
         const it = lowerBound(v.items, arr[i]);
         if (it == v.items.len) {
-            _ = v.append(arr[i]) catch return 0;
+            _ = v.append(allocator, arr[i]) catch return 0;
         } else {
             v.items[it] = arr[i];
         }

--- a/runall.zig
+++ b/runall.zig
@@ -61,8 +61,8 @@ fn runTest(allocator: std.mem.Allocator, comptime algorithm: []const u8) !void {
         "-Dalgorithm=" ++ algorithm,
     } ++ args, allocator);
 
-    child.stderr = std.io.getStdErr();
-    child.stdout = std.io.getStdOut();
+    child.stderr = std.fs.File.stderr();
+    child.stdout = std.fs.File.stdout();
 
     _ = try child.spawnAndWait();
 }

--- a/search/binarySearchTree.zig
+++ b/search/binarySearchTree.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const print = std.debug.print;
 const ArrayList = std.ArrayList;
+const Allocator = std.mem.Allocator;
 const testing = std.testing;
 
 // Returns a binary search tree instance.
@@ -22,7 +23,7 @@ pub fn BinarySearchTree(comptime T: type) type {
             left: ?*node = null,
         };
 
-        allocator: *std.mem.Allocator,
+        allocator: *Allocator,
         root: ?*node = null,
         size: usize = 0,
 
@@ -56,27 +57,27 @@ pub fn BinarySearchTree(comptime T: type) type {
         }
 
         // Function that performs inorder traversal of the tree
-        pub fn inorder(self: *Self, path: *ArrayList(T)) !void {
+        pub fn inorder(self: *Self, allocator: Allocator, path: *ArrayList(T)) !void {
             if (self.root == null) {
                 return;
             }
-            try self._inorder(self.root, path);
+            try self._inorder(allocator, self.root, path);
         }
 
         // Function that performs preorder traversal of the tree
-        pub fn preorder(self: *Self, path: *ArrayList(T)) !void {
+        pub fn preorder(self: *Self, allocator: Allocator, path: *ArrayList(T)) !void {
             if (self.root == null) {
                 return;
             }
-            try self._preorder(self.root, path);
+            try self._preorder(allocator, self.root, path);
         }
 
         // Function that performs postorder traversal of the tree
-        pub fn postorder(self: *Self, path: *ArrayList(T)) !void {
+        pub fn postorder(self: *Self, allocator: Allocator, path: *ArrayList(T)) !void {
             if (self.root == null) {
                 return;
             }
-            try self._postorder(self.root, path);
+            try self._postorder(allocator, self.root, path);
         }
 
         // Function that destroys the allocated memory of the whole tree
@@ -159,27 +160,27 @@ pub fn BinarySearchTree(comptime T: type) type {
             return false;
         }
 
-        fn _inorder(self: *Self, root: ?*node, path: *ArrayList(T)) !void {
+        fn _inorder(self: *Self, allocator: Allocator, root: ?*node, path: *ArrayList(T)) !void {
             if (root != null) {
-                try self._inorder(root.?.left, path);
-                try path.append(root.?.info);
-                try self._inorder(root.?.right, path);
+                try self._inorder(allocator, root.?.left, path);
+                try path.append(allocator, root.?.info);
+                try self._inorder(allocator, root.?.right, path);
             }
         }
 
-        fn _preorder(self: *Self, root: ?*node, path: *ArrayList(T)) !void {
+        fn _preorder(self: *Self, allocator: Allocator, root: ?*node, path: *ArrayList(T)) !void {
             if (root != null) {
-                try path.append(root.?.info);
-                try self._preorder(root.?.left, path);
-                try self._preorder(root.?.right, path);
+                try path.append(allocator, root.?.info);
+                try self._preorder(allocator, root.?.left, path);
+                try self._preorder(allocator, root.?.right, path);
             }
         }
 
-        fn _postorder(self: *Self, root: ?*node, path: *ArrayList(T)) !void {
+        fn _postorder(self: *Self, allocator: Allocator, root: ?*node, path: *ArrayList(T)) !void {
             if (root != null) {
-                try self._postorder(root.?.left, path);
-                try self._postorder(root.?.right, path);
-                try path.append(root.?.info);
+                try self._postorder(allocator, root.?.left, path);
+                try self._postorder(allocator, root.?.right, path);
+                try path.append(allocator, root.?.info);
             }
         }
 
@@ -244,26 +245,26 @@ test "Testing traversal methods" {
     try t.insert(12);
     try t.insert(15);
 
-    var ino = ArrayList(i32).init(allocator);
-    defer ino.deinit();
+    var ino: ArrayList(i32) = .empty;
+    defer ino.deinit(allocator);
 
     const check_ino = [_]i32{ 3, 5, 12, 15, 25 };
-    try t.inorder(&ino);
+    try t.inorder(allocator, &ino);
     try testing.expect(std.mem.eql(i32, ino.items, &check_ino));
 
-    var pre = ArrayList(i32).init(allocator);
-    defer pre.deinit();
+    var pre: ArrayList(i32) = .empty;
+    defer pre.deinit(allocator);
 
     const check_pre = [_]i32{ 5, 3, 25, 12, 15 };
-    try t.preorder(&pre);
+    try t.preorder(allocator, &pre);
 
     try testing.expect(std.mem.eql(i32, pre.items, &check_pre));
 
-    var post = ArrayList(i32).init(allocator);
-    defer post.deinit();
+    var post: ArrayList(i32) = .empty;
+    defer post.deinit(allocator);
 
     const check_post = [_]i32{ 3, 15, 12, 25, 5 };
-    try t.postorder(&post);
+    try t.postorder(allocator, &post);
 
     try testing.expect(std.mem.eql(i32, post.items, &check_post));
 }

--- a/web/http/client.zig
+++ b/web/http/client.zig
@@ -6,15 +6,13 @@ test "Status == 200" {
         .allocator = std.testing.allocator,
     };
     defer client.deinit();
-    var buffer: [4 * 1024]u8 = undefined;
-    var req = try client.open(.GET, uri, .{
-        .server_header_buffer = &buffer,
-    });
+
+    var req = try client.request(.GET, uri, .{});
     defer req.deinit();
 
-    try req.send();
-    try req.wait();
+    try req.sendBodiless();
+    const response = try req.receiveHead(&.{});
 
-    try std.testing.expectEqual(req.response.status, .ok);
-    try std.testing.expectEqual(req.response.version, .@"HTTP/1.1");
+    try std.testing.expectEqual(response.head.status, .ok);
+    try std.testing.expectEqual(response.head.version, .@"HTTP/1.1");
 }


### PR DESCRIPTION
release notes of v0.15.1: https://ziglang.org/download/0.15.1/release-notes.html

- Bump `minimum_zig_version` from "0.14.0" → "0.15.1"
- Update `test_runner` (dependencies)
- Adjust `ArrayList` usage to match v0.15 (now unmanaged by default)
- Migrate to Zig v0.15 `std.http` API
- Make `build.zig` match `runall.zig` for `numerical_methods/newton_raphson` (remove `_root`) so the test is actually executed by the helper.