### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows/"
+    schedule:
+      interval: "daily"
+...


### PR DESCRIPTION
Some of the dependencies are out of date, e.g.:
https://github.com/TheAlgorithms/Zig/blob/745a7fd5c3db1cab005bb8e7af11b206c95de12e/.github/workflows/CI.yml#L13

This PR configures dependabot, to keep them up-to-date.